### PR TITLE
Verify org membership before allowing merge

### DIFF
--- a/sample.ini
+++ b/sample.ini
@@ -34,6 +34,7 @@ jenkins.merge.trigger = $$merge$$
 
 # Which github namespace are we looking for this project. It should
 # be an Organization.
+# Members of this organization must be publicized in order to land merges.
 github.owner = CanonicalJS
 # The project that we are watching for pull requests.
 github.project = juju-gui

--- a/src/jenkinsgithublander/github.py
+++ b/src/jenkinsgithublander/github.py
@@ -27,6 +27,25 @@ def _build_url(route, request_info):
     return url
 
 
+def _is_mergeable(comment, owner, trigger, request_info):
+    """Determine if a given comment is a mergable request.
+
+    :param comment: The dict of the comment from the api.
+    :param owner: The repos owner data from the api.
+    :param trigger: The word/phrase to trigger a merge.
+    :param request_info: The tuple of info to make a valid api request.
+
+    """
+    user = comment['user']['login']
+    org = owner['login']
+    if trigger in comment['body'] and user_is_in_org(user,
+                                                     org,
+                                                     request_info):
+        return True
+    else:
+        return False
+
+
 def _json_resp(response):
     """Given a response, return the json of the resp and check for errors."""
     if response.status_code == 200:
@@ -54,6 +73,20 @@ def get_pull_request_comments(url, request_info):
     return _json_resp(resp)
 
 
+def user_is_in_org(user, org, request_info):
+    """Check if a user is in a specific org."""
+    path = '/users/{0}/orgs'.format(user)
+    url = _build_url(path, request_info)
+
+    resp = _json_resp(requests.get(url))
+
+    for org_found in resp:
+        if org_found['login'] == org:
+            return True
+
+    return False
+
+
 def mergeable_pull_requests(trigger_word, request_info):
     """Find the links to the issue comments where a command to merge lives."""
     prs = get_open_pull_requests(request_info)
@@ -68,7 +101,12 @@ def mergeable_pull_requests(trigger_word, request_info):
 
             if comments:
                 for comment in comments:
-                    if trigger_word in comment['body']:
+                    owner = pr['base']['user']
+                    if _is_mergeable(comment,
+                                     owner,
+                                     trigger_word,
+                                     request_info):
                         mergable_prs.append(pr)
+                        break
 
     return mergable_prs

--- a/src/jenkinsgithublander/tests/data/github-user-orgs.json
+++ b/src/jenkinsgithublander/tests/data/github-user-orgs.json
@@ -1,0 +1,32 @@
+[
+  {
+    "login": "CanonicalJS",
+    "id": 1969999,
+    "url": "https://api.github.com/orgs/CanonicalJS",
+    "repos_url": "https://api.github.com/orgs/CanonicalJS/repos",
+    "events_url": "https://api.github.com/orgs/CanonicalJS/events",
+    "members_url": "https://api.github.com/orgs/CanonicalJS/members{/member}",
+    "public_members_url": "https://api.github.com/orgs/CanonicalJS/public_members{/member}",
+    "avatar_url": "https://0.gravatar.com/avatar/5d02a15967cb6388bd3873b6e3b1362a?d=https%3A%2F%2Fidenticons.github.com%2F435ba347d6ed2d688587903b8139cc79.png&r=x"
+  },
+  {
+    "login": "coffeehousecoders",
+    "id": 3318938,
+    "url": "https://api.github.com/orgs/coffeehousecoders",
+    "repos_url": "https://api.github.com/orgs/coffeehousecoders/repos",
+    "events_url": "https://api.github.com/orgs/coffeehousecoders/events",
+    "members_url": "https://api.github.com/orgs/coffeehousecoders/members{/member}",
+    "public_members_url": "https://api.github.com/orgs/coffeehousecoders/public_members{/member}",
+    "avatar_url": "https://2.gravatar.com/avatar/1eb3723489b142b334bb12fcc77a4601?d=https%3A%2F%2Fidenticons.github.com%2F59ffa624be3e26035c3ca0d2de8568c2.png&r=x"
+  },
+  {
+    "login": "bookieio",
+    "id": 4212191,
+    "url": "https://api.github.com/orgs/bookieio",
+    "repos_url": "https://api.github.com/orgs/bookieio/repos",
+    "events_url": "https://api.github.com/orgs/bookieio/events",
+    "members_url": "https://api.github.com/orgs/bookieio/members{/member}",
+    "public_members_url": "https://api.github.com/orgs/bookieio/public_members{/member}",
+    "avatar_url": "https://2.gravatar.com/avatar/7423594cfd0acdbcae3b023aaf25287d?d=https%3A%2F%2Fidenticons.github.com%2F1c1203a343c14605295ec9885170ed3a.png&r=x"
+  }
+]

--- a/src/jenkinsgithublander/tests/test_jobs.py
+++ b/src/jenkinsgithublander/tests/test_jobs.py
@@ -15,6 +15,15 @@ class TestJobs(TestCase):
     def test_merge_pull_request_kicker(self):
         # Fake out the data for the github requests.
         pulls = load_data('github-open-pulls.json')
+        orgs = load_data('github-user-orgs.json')
+        comments = load_data('github-pull-request-comments.json')
+        responses.add(
+            responses.GET,
+            'https://api.github.com/users/mitechie/orgs',
+            body=orgs,
+            status=200,
+            content_type='application/json'
+        )
         responses.add(
             responses.GET,
             'https://api.github.com/repos/CanonicalJS/juju-gui/pulls',
@@ -22,8 +31,6 @@ class TestJobs(TestCase):
             status=200,
             content_type='application/json'
         )
-
-        comments = load_data('github-pull-request-comments.json')
         responses.add(
             responses.GET,
             (


### PR DESCRIPTION
- Add a new check for a user's membership when processing pull request comments
- Verify that the owner of the base repo is an org the user is a member of.
- Update tests for this new check.
